### PR TITLE
Change owlexplanation pom.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,10 @@
     <groupId>net.sourceforge.owlapi</groupId>
     <artifactId>owlexplanation</artifactId>
     <version>1.1.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
+    <packaging>bundle</packaging>
+    <description>OWL Explanation Generator - see
+        http://www.bcs.org/upload/pdf/dd-matthew-horridge.pdf
+    </description>
     <scm>
         <url>git@github.com:matthewhorridge/owlexplanation.git</url>
         <connection>scm:git:git://github.com/matthewhorridge/owlexplanation.git</connection>
@@ -41,14 +43,20 @@
 
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
-            <artifactId>owlapi-distribution</artifactId>
-            <version>3.5.1</version>
+            <artifactId>owlapi-osgidistribution</artifactId>
+            <version>[3.5.1,3.5.9]</version>
         </dependency>
 
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>telemetry</artifactId>
-            <version>1.0.0</version>
+            <version>[1,2)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sourceforge.owlapi</groupId>
+                    <artifactId>owlapi-distribution</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>
@@ -100,6 +108,21 @@
                     <source>1.7</source>
                     <target>1.7</target>
                     <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Implementation-Vendor>Matthew Horridge</Implementation-Vendor>
+                        <Bundle-Vendor>Matthew Horridge</Bundle-Vendor>
+                        <Export-Package>{local-packages}</Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
1:  Add description, with URL pointing to Horridge (2011).
2:  Change owlapi version dependency to be [3.5.1 to 3.5.9]
3:  Change telemetry version dependency to be any version <2 where 2.0.0-SNAPSHOT < 2
4:  Exclude transitive owlapi import from telemetry.
5:  Change packaging type to bundle.  Doesn't *seem* to be actively harmful. 